### PR TITLE
Fix undefined RNG in exported sampler

### DIFF
--- a/src/PoissonRandom.jl
+++ b/src/PoissonRandom.jl
@@ -1,8 +1,8 @@
-__precompile__()
-
 module PoissonRandom
 
 using Random
+
+export pois_rand
 
 function count_rand(λ,rng::AbstractRNG=Random.GLOBAL_RNG)
     n = 0
@@ -139,14 +139,12 @@ function procf(λ, K::Int, s::Float64)
     return px,py,fx,fy
 end
 
-function pois_rand(λ,rng::AbstractRNG=Base.GLOBAL_RNG)
+function pois_rand(λ,rng::AbstractRNG=Random.GLOBAL_RNG)
   if λ < 6
     return count_rand(λ,rng)
   else
     return ad_rand(λ,rng)
   end
 end
-
-export pois_rand
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -82,3 +82,8 @@ println("testing ad random sampler")
 for λ in [5.0, 10.0, 15.0, 20.0, 30.0]
   test_samples(PoissonRandom.ad_rand, Distributions.Poisson(λ), n_tsamples)
 end
+
+println("testing mixed random sampler")
+for λ in [5.0, 10.0, 15.0, 20.0, 30.0]
+  test_samples(pois_rand, Distributions.Poisson(λ), n_tsamples)
+end


### PR DESCRIPTION
This PR fixes the error
```julia
ERROR: LoadError: UndefVarError: GLOBAL_RNG not defined
```
when calling `pois_rand`.

BTW, what's the reason for having these samplers in a separate package and not just using/improving the [implementations in Distributions](https://github.com/JuliaStats/Distributions.jl/blob/master/src/samplers/poisson.jl)? Is it to keep the number of dependencies low? And wouldn't it be fairer to benchmark against these samplers as well and not only against Rmath which is [called by `rand(Poisson(λ))`](https://github.com/JuliaStats/Distributions.jl/blob/master/src/univariate/discrete/poisson.jl#L89)?