### PR TITLE
Remove internal `rand`, `randn`, and `randexp`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PoissonRandom"
 uuid = "e409e4f3-bfea-5376-8464-e040bb5c01ab"
-version = "0.4.6"
+version = "0.4.7"
 
 [deps]
 LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"

--- a/src/PoissonRandom.jl
+++ b/src/PoissonRandom.jl
@@ -8,9 +8,9 @@ export pois_rand, PassthroughRNG
 # GPU-compatible Poisson sampling via PassthroughRNG
 struct PassthroughRNG <: AbstractRNG end
 
-rand(rng::PassthroughRNG) = Random.rand()
-randexp(rng::PassthroughRNG) = Random.randexp()
-randn(rng::PassthroughRNG) = Random.randn()
+Random.rand(rng::PassthroughRNG) = rand()
+Random.randexp(rng::PassthroughRNG) = randexp()
+Random.randn(rng::PassthroughRNG) = randn()
 
 count_rand(λ) = count_rand(Random.GLOBAL_RNG, λ)
 function count_rand(rng::AbstractRNG, λ)

--- a/src/PoissonRandom.jl
+++ b/src/PoissonRandom.jl
@@ -12,10 +12,6 @@ rand(rng::PassthroughRNG) = Random.rand()
 randexp(rng::PassthroughRNG) = Random.randexp()
 randn(rng::PassthroughRNG) = Random.randn()
 
-rand(rng::AbstractRNG) = Random.rand(rng)
-randexp(rng::AbstractRNG) = Random.randexp(rng)
-randn(rng::AbstractRNG) = Random.randn(rng)
-
 count_rand(λ) = count_rand(Random.GLOBAL_RNG, λ)
 function count_rand(rng::AbstractRNG, λ)
     n = 0


### PR DESCRIPTION
An alternative to/extension of #56.