### PR TITLE
Fix deprecation warnings

### DIFF
--- a/src/PoissonRandom.jl
+++ b/src/PoissonRandom.jl
@@ -13,7 +13,7 @@ Random.rand(rng::PassthroughRNG) = rand()
 Random.randexp(rng::PassthroughRNG) = randexp()
 Random.randn(rng::PassthroughRNG) = randn()
 
-count_rand(λ::Real) = count_rand(Random.GLOBAL_RNG, λ)
+count_rand(λ::Real) = count_rand(Random.default_rng(), λ)
 function count_rand(rng::AbstractRNG, λ::Real)
     n = 0
     c = randexp(rng)
@@ -32,7 +32,7 @@ end
 #
 #   For μ sufficiently large, (i.e. >= 10.0)
 #
-ad_rand(λ::Real) = ad_rand(Random.GLOBAL_RNG, λ)
+ad_rand(λ::Real) = ad_rand(Random.default_rng(), λ)
 function ad_rand(rng::AbstractRNG, λ::Real)
     s = sqrt(λ)
     d = 6 * λ^2
@@ -135,7 +135,7 @@ pois_rand(rng, λ)
 pois_rand(PoissonRandom.PassthroughRNG(), λ)
 ```
 """
-pois_rand(λ::Real) = pois_rand(Random.GLOBAL_RNG, λ)
+pois_rand(λ::Real) = pois_rand(Random.default_rng(), λ)
 pois_rand(rng::AbstractRNG, λ::Real) = λ < 6 ? count_rand(rng, λ) : ad_rand(rng, λ)
 
 @compile_workload begin


### PR DESCRIPTION
## Summary
- Replace `Random.GLOBAL_RNG` with `Random.default_rng()` in all 3 call sites (`count_rand`, `ad_rand`, `pois_rand`)
- `Random.GLOBAL_RNG` is not exported from `Random` and is not part of the public API. `Random.default_rng()` is the supported public interface
- Both return `TaskLocalRNG` on Julia 1.10+, so this is a no-op behavior change but future-proofs against `GLOBAL_RNG` being deprecated

## Test plan
- [x] All tests pass with `JULIA_DEPWARN=error` on Julia 1.12.4
- [x] Aqua, JET, ExplicitImports, AllocCheck, and statistical tests all pass
- [x] Runic formatting check passes

## Upstream deps needing fixes
- None identified — all upstream dependencies (LogExpFunctions, PrecompileTools, Distributions, etc.) pass cleanly with `JULIA_DEPWARN=error`

🤖 Generated with [Claude Code](https://claude.com/claude-code)