### PR TITLE
Make PassthroughRNG dispatch survive overlay method-table shadowing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PoissonRandom"
 uuid = "e409e4f3-bfea-5376-8464-e040bb5c01ab"
-version = "0.4.7"
+version = "0.4.8"
 
 [deps]
 LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"

--- a/src/PoissonRandom.jl
+++ b/src/PoissonRandom.jl
@@ -13,6 +13,15 @@ Random.rand(rng::PassthroughRNG) = rand()
 Random.randexp(rng::PassthroughRNG) = randexp()
 Random.randn(rng::PassthroughRNG) = randn()
 
+# When an overlay method table (e.g. CUDA.jl's `@device_override
+# Random.randexp(::AbstractRNG)`) shadows the methods above, the overlay body
+# runs with rng::PassthroughRNG and may call `Random.rand(rng, UInt52Raw())`
+# or `Random.rand(rng, T)`. The stdlib Sampler chain bottoms out at
+# `_rand52(r, rng_native_52(r))` → `rand(r, UInt64)`; provide those so the
+# chain still reaches bare rand(T) and the device-side default_rng path.
+Random.rng_native_52(::PassthroughRNG) = UInt64
+Random.rand(rng::PassthroughRNG, ::Type{T}) where {T} = rand(T)
+
 count_rand(λ::Real) = count_rand(Random.default_rng(), λ)
 function count_rand(rng::AbstractRNG, λ::Real)
     n = 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -116,6 +116,22 @@ end
     end
 end
 
+@testset "PassthroughRNG dispatch" begin
+    using Random: Random, UInt52Raw
+    prng = PassthroughRNG()
+    # The CUDA.jl @device_override Random.randexp(::AbstractRNG) shadows our
+    # specific Random.randexp(::PassthroughRNG) on the GPU because Julia's
+    # OverlayMethodTable returns overlay matches without consulting the base
+    # table when the overlay fully covers the signature. The override body
+    # then calls these against PassthroughRNG; if they MethodError, kernel
+    # compilation fails with InvalidIRError on jl_f_throw_methoderror.
+    @test Random.rng_native_52(prng) === UInt64
+    @test Random.rand(prng, UInt52Raw()) isa UInt64
+    @test Random.rand(prng, UInt64) isa UInt64
+    @test Random.rand(prng, Float32) isa Float32
+    @test Random.rand(prng, Float64) isa Float64
+end
+
 if get(ENV, "GROUP", "all") == "all" || get(ENV, "GROUP", "all") == "nopre"
     @testset "Allocation Tests" begin
         include("alloc_tests.jl")


### PR DESCRIPTION
Closes the root cause behind [SciML/JumpProcesses.jl#588](https://github.com/SciML/JumpProcesses.jl/issues/588).

## Summary
`PassthroughRNG` previously defined only the three no-second-arg methods (`rand`, `randexp`, `randn`). On Julia 1.12+, GPU back ends like CUDA.jl install device-side overlay tables via `Base.Experimental.@consistent_overlay`. Julia's `OverlayMethodTable.findall` (Compiler/src/methodtable.jl:73–92) returns overlay matches **without consulting the base method table** whenever the overlay fully covers the signature:

```julia
if nr ≥ 1 && result[nr].fully_covers
    # no need to fall back to the internal method table
    return result
end
```

CUDA.jl's `@device_override Random.randexp(rng::AbstractRNG)` therefore shadows our specific `Random.randexp(::PassthroughRNG)` on the device — the more specific base-table method is *never seen by inference*. The override's body then runs with `rng::PassthroughRNG` and calls `Random.rand(rng, UInt52Raw())`. The stdlib Sampler chain for that bottoms out at `_rand52(r, rng_native_52(r)) → rand(r, UInt64)`; `PassthroughRNG` had no `rng_native_52` and no typed-arg `rand`, so the chain statically reached `throw(MethodError, ...)` and GPUCompiler refused to lower the kernel:

```
InvalidIRError: ... resulted in invalid LLVM IR
Reason: unsupported call to an unknown function (call to jl_f_throw_methoderror)
Stacktrace:
 [1] rand        @ Random/src/generation.jl:114
 [2] rand        @ Random/src/Random.jl:255
 [3] randexp     @ CUDACore/src/device/random.jl:339   (device_override)
```

Confirmed on Julia 1.12.6 by directly calling `Random.rand(PassthroughRNG(), Random.UInt52Raw())` on the CPU — the top two frames match the GPU `InvalidIRError` frames exactly.

## Fix
Two forwarding methods so the Sampler chain bottoms out at bare `rand(T)`:

```julia
Random.rng_native_52(::PassthroughRNG) = UInt64
Random.rand(rng::PassthroughRNG, ::Type{T}) where {T} = rand(T)
```

These preserve `PassthroughRNG`'s ''use whatever `default_rng()` returns here'' semantics — bare `rand(T)` goes through `default_rng()`, which GPU back ends device-override to their device RNG (`Philox2x32` in CUDA.jl). Verified locally on Julia 1.12.6:

```
rng_native_52(prng):  UInt64
rand(prng, UInt52Raw()):  2033734290634309481
rand(prng, UInt64):  11777094854860645014
rand(prng, Float32):  0.98086137
rand(prng, Float64):  0.9338644122927825
pois_rand(prng, 3.0):  3
pois_rand(prng, 50.0):  52
```

Added a regression test (`@testset "PassthroughRNG dispatch"`) covering each of these calls. Bumped version 0.4.7 → 0.4.8.

## Test plan
- [x] Full `Pkg.test()` green on Julia 1.12.6 — Aqua (10/10), JET static analysis (6/6), ExplicitImports (2/2), BigFloat (401/401), PassthroughRNG dispatch (5/5), Allocation Tests (10/10), and the count/ad/mixed statistical samplers.
- [ ] CI green.

## Notes
- Please ignore until reviewed by @ChrisRackauckas.
- This doesn't pull in a dependency on RandomNumbers.jl (alternative would have been to make `PassthroughRNG <: RandomNumbers.AbstractRNG{UInt64}` and inherit the `rng_native_52` fallback — heavier and changes the package's dep graph).
- There is a separate, downstream CUDA.jl issue exposed once this PR unblocks the dispatch chain: `@noinline randexp_unlikely` in the device `randexp` override (line 345) triggers `julia.get_pgcstack` on Julia 1.12 — that needs an upstream fix in CUDA.jl and is not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)