### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -13,21 +13,10 @@ on:
 jobs:
   test:
     if: false
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-#        if: ${{ matrix.version == '1.6' }}
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    name: "Downgrade"
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+      allow-reresolve: false
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -5,9 +5,5 @@ on: [pull_request]
 jobs:
   typos-check:
     name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.1 
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts the remaining inline CI checks to the centralized SciML reusable workflows (all pinned `@v1`, every caller uses `secrets: "inherit"`).

## Converted (inline -> central)
- **FormatCheck.yml (Runic)**: `fredrikekre/runic-action` -> `SciML/.github/.github/workflows/runic.yml@v1`
- **SpellCheck.yml (typos)**: `crate-ci/typos` -> `SciML/.github/.github/workflows/spellcheck.yml@v1`
- **Downgrade.yml**: inline downgrade job -> `SciML/.github/.github/workflows/downgrade.yml@v1`, preserving `if: false` (still disabled), `julia-version: "1.10"`, `skip: "Pkg,TOML"`, `allow-reresolve: false`

## Already central (left as-is, confirmed `secrets: "inherit"`)
- **Tests.yml**: `tests.yml@v1` with the exact version × os matrix (`1`/`lts`/`pre` × ubuntu/macos/windows)
- **Documentation.yml**: `documentation.yml@v1`

## Other changes
- **dependabot.yml**: removed the `crate-ci/typos` ignore entry (no longer relevant once spellcheck is centralized); github-actions (weekly, `/`) and julia (daily, all-julia-packages, dirs `/`, `/docs`, `/test`) blocks preserved.

## Verification
- Typos fixed: 0 (`typos .` is clean, exit 0).
- Runic: no formatting changes needed (repo was already Runic-clean from the prior inline check).
- All changed YAML validated with `yaml.safe_load`.

## Note
Check **names will change** (now reported by the reusable workflows). Branch-protection required-status-check names will need updating after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)