### PR TITLE
QA: run_qa v1.6 form + ExplicitImports

### DIFF
--- a/src/PoissonRandom.jl
+++ b/src/PoissonRandom.jl
@@ -9,9 +9,9 @@ export pois_rand, PassthroughRNG
 # GPU-compatible Poisson sampling via PassthroughRNG
 struct PassthroughRNG <: AbstractRNG end
 
-Random.rand(rng::PassthroughRNG) = rand()
+Base.rand(rng::PassthroughRNG) = rand()
 Random.randexp(rng::PassthroughRNG) = randexp()
-Random.randn(rng::PassthroughRNG) = randn()
+Base.randn(rng::PassthroughRNG) = randn()
 
 # When an overlay method table (e.g. CUDA.jl's `@device_override
 # Random.randexp(::AbstractRNG)`) shadows the methods above, the overlay body
@@ -20,7 +20,7 @@ Random.randn(rng::PassthroughRNG) = randn()
 # `_rand52(r, rng_native_52(r))` → `rand(r, UInt64)`; provide those so the
 # chain still reaches bare rand(T) and the device-side default_rng path.
 Random.rng_native_52(::PassthroughRNG) = UInt64
-Random.rand(rng::PassthroughRNG, ::Type{T}) where {T} = rand(T)
+Base.rand(rng::PassthroughRNG, ::Type{T}) where {T} = rand(T)
 
 count_rand(λ::Real) = count_rand(Random.default_rng(), λ)
 function count_rand(rng::AbstractRNG, λ::Real)

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,9 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 PoissonRandom = "e409e4f3-bfea-5376-8464-e040bb5c01ab"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -13,10 +11,8 @@ PoissonRandom = {path = "../.."}
 
 [compat]
 Aqua = "0.8"
-ExplicitImports = "1.14.0"
 JET = "0.9, 0.10, 0.11"
-Random = "1.10"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,36 +1,12 @@
-using PoissonRandom, Aqua, JET, ExplicitImports
-using Random
-using Test
+using SciMLTesting, PoissonRandom, JET, Test
 
-@testset "Aqua" begin
-    Aqua.find_persistent_tasks_deps(PoissonRandom)
-    Aqua.test_ambiguities(PoissonRandom, recursive = false)
-    Aqua.test_deps_compat(PoissonRandom)
-    Aqua.test_piracies(
-        PoissonRandom,
-        treat_as_own = []
-    )
-    Aqua.test_project_extras(PoissonRandom)
-    Aqua.test_stale_deps(PoissonRandom)
-    Aqua.test_unbound_args(PoissonRandom)
-    Aqua.test_undefined_exports(PoissonRandom)
-end
-
-@testset "JET static analysis" begin
-    @testset "Type stability" begin
-        JET.@test_opt target_modules = (PoissonRandom,) pois_rand(10.0)
-        JET.@test_opt target_modules = (PoissonRandom,) pois_rand(Random.default_rng(), 10.0)
-        JET.@test_opt target_modules = (PoissonRandom,) pois_rand(PassthroughRNG(), 10.0)
-    end
-
-    @testset "Error analysis" begin
-        JET.@test_call target_modules = (PoissonRandom,) pois_rand(10.0)
-        JET.@test_call target_modules = (PoissonRandom,) pois_rand(Random.default_rng(), 10.0)
-        JET.@test_call target_modules = (PoissonRandom,) pois_rand(PassthroughRNG(), 10.0)
-    end
-end
-
-@testset "ExplicitImports" begin
-    @test check_no_implicit_imports(PoissonRandom) === nothing
-    @test check_no_stale_explicit_imports(PoissonRandom) === nothing
-end
+run_qa(
+    PoissonRandom;
+    explicit_imports = true,
+    ei_kwargs = (;
+        # default_rng / rng_native_52 are Random stdlib internals (not public in
+        # Random): default_rng is the standard default-RNG accessor; rng_native_52 is
+        # extended for the PassthroughRNG sampler chain.
+        all_qualified_accesses_are_public = (; ignore = (:default_rng, :rng_native_52)),
+    ),
+)


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts `test/qa/qa.jl` from the hand-rolled Aqua/JET/ExplicitImports body to the SciMLTesting v1.6 `run_qa` form with `explicit_imports = true` (all 6 ExplicitImports checks now run).

## ExplicitImports findings

| Check | Result |
|---|---|
| `no_implicit_imports` | pass (no change) |
| `no_stale_explicit_imports` | pass (no change) |
| `all_explicit_imports_via_owners` | pass (no change) |
| `all_explicit_imports_are_public` | pass (no change) |
| `all_qualified_accesses_via_owners` | **FIXED** in source |
| `all_qualified_accesses_are_public` | **IGNORE** (2 Random stdlib internals) |

**FIX (`all_qualified_accesses_via_owners`):** `rand`/`randn` are owned by `Base` and only re-exported by `Random`, so the `PassthroughRNG` methods are now defined as `Base.rand`/`Base.randn` instead of `Random.rand`/`Random.randn`. `Random.randexp` / `Random.rng_native_52` / `Random.default_rng` are genuinely `Random`-owned and unchanged.

**IGNORE (`all_qualified_accesses_are_public`):** `default_rng` and `rng_native_52` are `Random` stdlib internals (not public in `Random`): `default_rng` is the standard default-RNG accessor; `rng_native_52` is extended for the `PassthroughRNG` sampler chain. There is no way to make a stdlib's own non-public names public, so these are ignored via `ei_kwargs` with the source documented in a comment.

No `@test_broken` markers were needed (none existed previously; 0 hard fails after the fix + ignore).

## Deps (`test/qa/Project.toml`)

- `SciMLTesting` compat bumped to `"1.6"`.
- Dropped `ExplicitImports` (transitive via SciMLTesting) and `Random` (`qa.jl` no longer uses it).
- Kept `Aqua` (the ambiguities sub-check spawns a child process that needs Aqua a direct dep), `JET` (JET runs), `SafeTestsets` (the `run_tests` `@safetestset` wrapper must be able to load it in the QA env), and `Test`.

## Verification (vs released SciMLTesting 1.6.0, no dev-from-branch)

- QA group: **18/18 pass** on Julia 1.10 (lts) and 1.12 (release), 0 Fail/Broken/Error.
- Core group: passes on Julia 1.10 (confirms the `Base.rand`/`Base.randn` source change is behavior-preserving).

🤖 Generated with [Claude Code](https://claude.com/claude-code)