### PR TITLE
Bump version to 0.4.11

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PoissonRandom"
 uuid = "e409e4f3-bfea-5376-8464-e040bb5c01ab"
-version = "0.4.10"
+version = "0.4.11"
 
 [deps]
 LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"


### PR DESCRIPTION
Automated patch version bump (0.4.10 -> 0.4.11) to release unreleased commits on `master` via JuliaRegistrator.