### PR TITLE
Document PoissonRandom public APIs

### DIFF
--- a/docs/src/pois_rand.md
+++ b/docs/src/pois_rand.md
@@ -1,5 +1,6 @@
 # Poisson Random API
 
 ```@docs
+PassthroughRNG
 pois_rand
 ```

--- a/src/PoissonRandom.jl
+++ b/src/PoissonRandom.jl
@@ -6,7 +6,25 @@ using PrecompileTools: @compile_workload
 
 export pois_rand, PassthroughRNG
 
-# GPU-compatible Poisson sampling via PassthroughRNG
+"""
+    PassthroughRNG()
+
+An `AbstractRNG` sentinel for backend-specific random number generation.
+
+`PassthroughRNG` forwards scalar `rand`, `randn`, and `randexp` calls to the
+ambient random number implementation. It is useful when a backend, such as a GPU
+kernel overlay, provides the actual random number generation but an
+`AbstractRNG` argument is still needed by the Poisson sampler.
+
+# Examples
+
+```julia
+using PoissonRandom
+
+x = pois_rand(PassthroughRNG(), 3.0)
+x isa Integer
+```
+"""
 struct PassthroughRNG <: AbstractRNG end
 
 Base.rand(rng::PassthroughRNG) = rand()
@@ -122,26 +140,31 @@ function procf(λ::Real, K::Int, s::Real)
 end
 
 """
+    pois_rand(λ::Real)
+    pois_rand(rng::AbstractRNG, λ::Real)
+
+Draw one random variate from the Poisson distribution with rate `λ`.
+
+For small `λ`, `pois_rand` uses an exponential-counting method. For larger `λ`,
+it switches to the Ahrens-Dieter modified normal algorithm.
+
+# Arguments
+
+- `λ`: Poisson rate parameter. It should be nonnegative.
+- `rng`: optional random number generator. Defaults to `Random.default_rng()`.
+
+# Examples
+
 ```julia
-pois_rand(λ)
-pois_rand(rng::AbstractRNG, λ)
-```
+using PoissonRandom
+using Random
 
-Generates Poisson(λ) distributed random numbers using a fast polyalgorithm.
+rng = MersenneTwister(1234)
+x = pois_rand(rng, 4.0)
+x isa Integer
 
-## Examples
-
-```julia
-# Simple Poisson random
-pois_rand(λ)
-
-# Using another RNG
-using RandomNumbers
-rng = Xorshifts.Xoroshiro128Plus()
-pois_rand(rng, λ)
-
-# Simple Poisson random on GPU
-pois_rand(PoissonRandom.PassthroughRNG(), λ)
+y = pois_rand(PassthroughRNG(), 4.0)
+y isa Integer
 ```
 """
 pois_rand(λ::Real) = pois_rand(Random.default_rng(), λ)

--- a/test/qa/public_api_docs.jl
+++ b/test/qa/public_api_docs.jl
@@ -1,0 +1,17 @@
+using PoissonRandom
+using Test
+
+@testset "public API documentation" begin
+    public_names = filter(!=(:PoissonRandom), names(PoissonRandom; all = false, imported = false))
+    @test Set(public_names) == Set([:PassthroughRNG, :pois_rand])
+
+    for name in public_names
+        binding = Docs.Binding(PoissonRandom, name)
+        @test Docs.hasdoc(binding)
+    end
+
+    api_page = read(joinpath(pkgdir(PoissonRandom), "docs", "src", "pois_rand.md"), String)
+    for name in public_names
+        @test occursin(string(name), api_page)
+    end
+end

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,5 +1,7 @@
 using SciMLTesting, PoissonRandom, JET, Test
 
+include("public_api_docs.jl")
+
 run_qa(
     PoissonRandom;
     explicit_imports = true,


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- add a definition-point docstring for the exported `PassthroughRNG` type
- expand the `pois_rand` docstring with signatures, arguments, and runnable examples
- include `PassthroughRNG` on the rendered API page
- add a QA guard that checks exported APIs have source docs and API-page entries

## Validation

- `git diff --check origin/master...HEAD`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.test()'`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=test/qa -e 'using Pkg; Pkg.instantiate(); include("test/qa/qa.jl")'`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.instantiate(); using Runic; exit(Runic.main(["--check", "."]))'`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("docs/make.jl")'`