### PR TITLE
Release prep: bump PoissonRandom to 0.4.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PoissonRandom"
 uuid = "e409e4f3-bfea-5376-8464-e040bb5c01ab"
-version = "0.4.11"
+version = "0.4.12"
 
 [deps]
 LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"


### PR DESCRIPTION
Patch release for the accumulated docstring/QA/test scaffolding changes since 0.4.11 (no functional/behavioral changes).