### PR TITLE
Use default public API docs QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -3,7 +3,6 @@ using SciMLTesting, PoissonRandom, JET
 run_qa(
     PoissonRandom;
     explicit_imports = true,
-    api_docs_kwargs = (; rendered = true),
     ei_kwargs = (;
         # default_rng / rng_native_52 are Random stdlib internals (not public in
         # Random): default_rng is the standard default-RNG accessor; rng_native_52 is


### PR DESCRIPTION
Remove the repository-specific rendered API-docs option and use the standard SciMLTesting public API documentation check.

Validation:
- Runic 1.7 with docstrings
- `GROUP=QA Pkg.test()`
- `Pkg.test()`

Ignore until reviewed by @ChrisRackauckas.